### PR TITLE
reuse list removals for insertions in policy lists

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/graxinc/syncmap v0.0.0-20241016221111-1f2c2c6f98d1
 	github.com/hashicorp/golang-lru/arc/v2 v2.0.7
 	github.com/pkg/profile v1.7.0
-	github.com/szyhf/go-container v0.0.0-20221021071115-bc30d479be15
 	golang.org/x/exp v0.0.0-20221025133541-111beb427cde
 )
 

--- a/go.sum
+++ b/go.sum
@@ -28,8 +28,6 @@ github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSS
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
-github.com/szyhf/go-container v0.0.0-20221021071115-bc30d479be15 h1:mp2+gy3l6zufc2zCvl7XF31YTQheCQS8f0t8v6pKsk8=
-github.com/szyhf/go-container v0.0.0-20221021071115-bc30d479be15/go.mod h1:hRJc3GMZ1K1P88vIv1K5h5AHqkcJKHdH7nO2l2vTp6g=
 golang.org/x/exp v0.0.0-20221025133541-111beb427cde h1:21I041MHkLEAgTE3ziMHbCknpoSjQKUmXhIDgfpGiUo=
 golang.org/x/exp v0.0.0-20221025133541-111beb427cde/go.mod h1:cyybsKvd6eL0RnXn6p/Grxp8F5bW7iYuBgsNCOHpMYE=
 golang.org/x/sys v0.0.0-20211007075335-d3039528d8ac/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/policy/internal/internal.go
+++ b/policy/internal/internal.go
@@ -1,0 +1,140 @@
+package internal
+
+// originally from github.com/szyhf/go-container/list
+
+// Element is an element of a linked list.
+type Element[T any] struct {
+	// Next and previous pointers in the doubly-linked list of elements.
+	// To simplify the implementation, internally a list l is implemented
+	// as a ring, such that &l.root is both the next element of the last
+	// list element (l.Back()) and the previous element of the first list
+	// element (l.Front()).
+	next, prev *Element[T]
+
+	// The value stored with this element.
+	Value T
+}
+
+// List represents a doubly linked list.
+// The zero value for List is an empty list ready to use.
+type List[T any] struct {
+	root Element[T] // sentinel list element, only &root, root.prev, and root.next are used
+	len  int        // current list length excluding (this) sentinel element
+}
+
+// Init initializes or clears list l.
+func (l *List[T]) Init() *List[T] {
+	l.root.next = &l.root
+	l.root.prev = &l.root
+	l.len = 0
+	return l
+}
+
+func New[T any]() *List[T] {
+	return new(List[T]).Init()
+}
+
+// Len returns the number of elements of list l.
+// The complexity is O(1).
+func (l *List[T]) Len() int { return l.len }
+
+// Front returns the first element of list l or nil if the list is empty.
+func (l *List[T]) Front() *Element[T] {
+	if l.len == 0 {
+		return nil
+	}
+	return l.root.next
+}
+
+// Back returns the last element of list l or nil if the list is empty.
+func (l *List[T]) Back() *Element[T] {
+	if l.len == 0 {
+		return nil
+	}
+	return l.root.prev
+}
+
+// Next returns the next list element after e or nil.
+func (l *List[T]) Next(e *Element[T]) *Element[T] {
+	if p := e.next; p != &l.root {
+		return p
+	}
+	return nil
+}
+
+// Prev returns the previous list element before e or nil.
+func (l *List[T]) Prev(e *Element[T]) *Element[T] {
+	if p := e.prev; p != &l.root {
+		return p
+	}
+	return nil
+}
+
+// remove removes e from list, decrements l.len
+func (l *List[T]) Remove(e *Element[T]) {
+	e.prev.next = e.next
+	e.next.prev = e.prev
+	e.next = nil // avoid memory leaks
+	e.prev = nil // avoid memory leaks
+	l.len--
+}
+
+// PushFront inserts a new element or reset buf e with value v at the front of list l and returns e.
+func (l *List[T]) PushFront(buf *Element[T], v T) *Element[T] {
+	l.lazyInit()
+	return l.insertValue(buf, v, &l.root)
+}
+
+// MoveToFront moves element e to the front of list l.
+// If e is not an element of l, the list is not modified.
+// The element must not be nil.
+func (l *List[T]) MoveToFront(e *Element[T]) {
+	if l.root.next == e {
+		return
+	}
+	// see comment in List.Remove about initialization of l
+	l.move(e, &l.root)
+}
+
+// lazyInit lazily initializes a zero List value.
+func (l *List[T]) lazyInit() {
+	if l.root.next == nil {
+		l.Init()
+	}
+}
+
+// insertValue is a convenience wrapper for insert(&Element{Value: v}, at).
+func (l *List[T]) insertValue(buf *Element[T], v T, at *Element[T]) *Element[T] {
+	if buf == nil {
+		buf = &Element[T]{Value: v}
+	} else {
+		buf.next = nil
+		buf.prev = nil
+		buf.Value = v
+	}
+	return l.insert(buf, at)
+}
+
+// insert inserts e after at, increments l.len, and returns e.
+func (l *List[T]) insert(e, at *Element[T]) *Element[T] {
+	e.prev = at
+	e.next = at.next
+	e.prev.next = e
+	e.next.prev = e
+	l.len++
+	return e
+}
+
+// move moves e to next to at.
+func (l *List[T]) move(e, at *Element[T]) {
+	if e == at {
+		return
+	}
+	e.prev.next = e.next
+	e.next.prev = e.prev
+
+	e.prev = at
+	e.next = at.next
+	e.prev.next = e
+	e.next.prev = e
+}


### PR DESCRIPTION
old:
```
BenchmarkCache_memory-8   	       3	2070894136 ns/op	171105568 B/op	 3962128 allocs/op
PASS
ok  	github.com/graxinc/cache	12.127s
```

new:
```
BenchmarkCache_memory-8   	       3	1634825570 ns/op	115878714 B/op	 2837719 allocs/op
PASS
ok  	github.com/graxinc/cache	10.083s
```

bench cmp
```
BenchmarkCache_memory-8     2070894136     1634825570     -21.06%

benchmark                   old allocs     new allocs     delta
BenchmarkCache_memory-8     3962128        2837719        -28.38%

benchmark                   old bytes     new bytes     delta
BenchmarkCache_memory-8     171105568     115878714     -32.28%
```