### PR TITLE
add Stats to pass out policy params

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -264,6 +264,13 @@ func (a *Cache[K, V]) SetAvailableCapacity(available, max int64) {
 	a.SetCapacity(new)
 }
 
+func (a *Cache[K, V]) Stats() map[string]any {
+	a.policyMu.Lock()
+	defer a.policyMu.Unlock()
+
+	return map[string]any{"policy": a.policy.Stats()}
+}
+
 func (a *Cache[K, V]) get(k K) (*CacheValue[V], bool) {
 	v, ok := a.items.Get(k)
 	if !ok || a.expired(v.expire) {

--- a/cache_test.go
+++ b/cache_test.go
@@ -553,6 +553,30 @@ func TestCache_Sizer_random(t *testing.T) {
 	}
 }
 
+func TestCache_Stats(t *testing.T) {
+	t.Parallel()
+
+	a := cache.NewCache(cache.CacheOptions[int, struct{}]{})
+
+	a.Set(1, struct{}{})
+	a.Set(2, struct{}{})
+	a.Evict()
+	a.Set(3, struct{}{})
+	a.Promote(3)
+
+	got := a.Stats()
+	want := map[string]any{
+		"policy": map[string]any{
+			"b1Len":            int(1),
+			"b2Len":            int(0),
+			"t1Len":            int(1),
+			"t1TargetFraction": float64(0),
+			"t2Len":            int(1),
+		},
+	}
+	diffFatal(t, want, got)
+}
+
 func BenchmarkCache_memory(b *testing.B) {
 	rando := rand.New(rand.NewSource(5)) //nolint:gosec
 

--- a/counting/counting.go
+++ b/counting/counting.go
@@ -244,3 +244,7 @@ func (a Cache[K, V]) SwapCapacity(old, new int64) (swapped bool) {
 func (a Cache[K, V]) SetAvailableCapacity(available, max int64) {
 	a.cache.SetAvailableCapacity(available, max)
 }
+
+func (a Cache[K, V]) Stats() map[string]any {
+	return a.cache.Stats()
+}

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -24,6 +24,8 @@ type Policy[T any] interface {
 	// Hottest to coldest.
 	// Safe for RLock.
 	Values() iter.Seq[T]
+
+	Stats() map[string]any
 }
 
 type ARC[T comparable] struct {
@@ -163,7 +165,24 @@ type ARCParams struct {
 }
 
 func (c *ARC[T]) ARCParams() ARCParams {
-	return ARCParams{T1Len: c.t1.Len(), T2Len: c.t2.Len(), B1Len: c.b1.Len(), B2Len: c.b2.Len(), T1TargetFraction: c.t1TargetFraction}
+	return ARCParams{
+		T1Len:            c.t1.Len(),
+		T2Len:            c.t2.Len(),
+		B1Len:            c.b1.Len(),
+		B2Len:            c.b2.Len(),
+		T1TargetFraction: c.t1TargetFraction,
+	}
+}
+
+func (c *ARC[T]) Stats() map[string]any {
+	p := c.ARCParams()
+	return map[string]any{
+		"t1Len":            p.T1Len,
+		"t2Len":            p.T2Len,
+		"b1Len":            p.B1Len,
+		"b2Len":            p.B2Len,
+		"t1TargetFraction": p.T1TargetFraction,
+	}
 }
 
 // b1 must not be empty.


### PR DESCRIPTION
Never great that Stats with loose name/values can blur the boundary with other funcs return vals, but would like to get at these values in production for monitoring. Better options welcome! 